### PR TITLE
Remove redundant loop and set error pipefail on

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
-set -m
+set -meo pipefail
 
 function load_gm_data() {
   echo "Loading Guided Match decision tree data from file: ${1}"
-  until cypher-shell -u neo4j -p sbx_graph -a bolt://localhost:7687 --debug -f ./graph/$1
-  do
-    echo "Waiting for load of ${1} to complete..."
-    sleep 5
-  done
+  cypher-shell -u neo4j -p sbx_graph -a bolt://localhost:7687 --debug -f ./graph/$1
 }
 
 # Start the primary process in the background


### PR DESCRIPTION
This should ensure the container exits during startup if there is a cypher syntax error in one of the scripts, or a connection error (rather than leave the service 'up' in an inconsistent state compared to what we expect, e.g. some of the data but not all).  The main loop (`# Wait for Neo4j to start`) takes care of the wait - the second `until` loop is now redundant.