### PR TITLE
Additional outcome for WPS legal emp/lit bdgt under 20k

### DIFF
--- a/graph/RM3788_Legal_Services.cypher
+++ b/graph/RM3788_Legal_Services.cypher
@@ -86,6 +86,7 @@ CREATE
 (qiCentGovBudget)-[:HAS_ANSWER_GROUP]->(ansGrpCGBudgetKnown),
 (ansGrpCGBudgetKnown)-[:HAS_ANSWER {order: 1}]->(ansYesBudgetKnown)-[:HAS_CONDITIONAL_INPUT]->(qstnLegalFeesValue),
 (ansGrpCGBudgetKnown)-[:HAS_OUTCOME {lowerBoundInclusive: 0, upperBoundExclusive: 20000}]->(:Agreement:Outcome {number: 'RM3788'})-[:HAS_LOT]->(:Lot {number: '1', url: '', type: 'CAT', scale: true}),
+(ansGrpCGBudgetKnown)-[:HAS_OUTCOME {lowerBoundInclusive: 0, upperBoundExclusive: 20000}]->(:Agreement:Outcome {number: 'RM3786'}),
 (ansGrpCGBudgetKnown)-[:HAS_OUTCOME {lowerBoundInclusive: 20000, upperBoundExclusive: 9223372036854775807}]->(:Agreement:Outcome {number: 'RM3786'}),
 
 // Sector(CG) -> Service(Employment Litigation, Property, Litigation) -> Budget (unknown)


### PR DESCRIPTION
Might want to consider if there is a better way to model the conditional input where there are multiple outcomes to avoid duplicating the bounds - but this works as expected. 
Deployed to SBX2:

- https://sbx2.scale.crowncommercial.gov.uk/find-a-commercial-agreement/start-journey/ccb5c730-75b5-11ea-bc55-0242ac130003?q=legal
- Central Government
- Litigation
- Budget < £20k
- Now see two agreements (GLAS and RM3788 Lot 1) in results page